### PR TITLE
Structuring of data folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,8 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+###########################
+
+# Data directory
+/data/gan-getting-started


### PR DESCRIPTION
Add data folder and gitignore entry for the path /data/gan-getting-started to constitute a common place for the data source without uploading it to git.